### PR TITLE
fix replace logic in server rendering script

### DIFF
--- a/server/universal.js
+++ b/server/universal.js
@@ -50,7 +50,7 @@ async function serverRender(req, res, htmlData){
   } else {
     // we're good, add in markup, send the response
     const RenderedApp = htmlData.replace('{{SSR}}', markup)
-      .replace('<meta-head/>', headMarkup)
+      .replace('<meta-head />', headMarkup)
       .replace('{{data}}', new Buffer(JSON.stringify(context.data)).toString('base64'))
     if (context.code)
       res.status(context.code)


### PR DESCRIPTION
the accompanying tag in `public/index.html` has a space before the tag closes.  Without these two matching, the `.replace()` will not work.